### PR TITLE
fix: python required and duplicate exclude key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     {name = "Gudbrand Tandberg", email = "gudbrandduff@fmail.com"},
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13"
 license = {text = "MIT"}
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -66,7 +66,6 @@ dev = [
 ultralytics = { git = "https://github.com/3lc-ai/ultralytics.git" }
 
 [tool.ruff]
-exclude = ["chessvision/pytorch_unet"]
 line-length = 120
 target-version = "py39"
 


### PR DESCRIPTION
Python 3.13 is not supported by 3lc

```
error: Distribution `3lc==2.12.1 @ registry+https://pypi.org/simple` can't be installed because it doesn't have a source distribution or wheel for the current platform

hint: You're using CPython 3.13 (`cp313`), but `3lc` (v2.12.1) only has wheels with the following Python ABI tags: `cp39`, `cp310`, `cp311`, `cp312`
```

---

I've also fix the duplicate exclude key in `[tool.ruff]`