### PR TITLE
docs: triage cleanup + restructure setup by audience

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,9 @@ in `chessvision/core.py`.
 ## Models / weights
 - **YOLO is the default and preferred path** for both board extraction and classification.
   UNet remains as a fallback only if `ultralytics` is unavailable.
-- Weights live in `weights/`, are **not** committed (Ultralytics AGPL licensing caution),
-  and are produced by the training scripts — they are our "current best models".
-  Present: `best_yolo_classifier.pt`, `best_yolo_extractor.pt`.
+- The two best models **are committed** in `weights/` (`best_yolo_classifier.pt`,
+  `best_yolo_extractor.pt`) — the repo is AGPL-3.0, so the weights ship in-repo (see the
+  ROADMAP decision log). They're produced by the training scripts — our "current best models".
 - Don't add weight-sync/fetch scripts; regenerate via `scripts/bin/train_*.sh`.
 
 ## Environment gotchas (macOS, verified 2026-06-08)
@@ -71,7 +71,7 @@ One-time setup:
 cd ~/projects/ChessVision-3LC
 uv venv                                                  # fresh .venv in the project
 uv sync --all-extras                                     # public deps (3lc 3.0 wheel, ultralytics, ...)
-uv pip install -e ../tlc-monorepo -e ../3lc-ultralytics  # editable source overlay (tlc 3.1)
+uv pip install -e ../tlc-monorepo -e ../3lc-ultralytics  # source overlay (API-compatible with the public 3.0 wheel)
 git submodule update --init                              # UNet submodule (only for the UNet path)
 ```
 The editable source overlay matters: the frozen `3lc` wheel ignores `TLC_DISABLE_ACCOUNT_SERVICE`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,42 +17,39 @@ in `chessvision/core.py`.
   ROADMAP decision log). They're produced by the training scripts — our "current best models".
 - Don't add weight-sync/fetch scripts; regenerate via `scripts/bin/train_*.sh`.
 
-## Environment gotchas (macOS, verified 2026-06-08)
-- **cairo**: installed via brew (`cairo` 1.18.4) but Python's `find_library` doesn't search
-  `/opt/homebrew/lib`. Export `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib` before any
-  command that imports `cairosvg` (eval / process-new-raw / render paths).
-- **3LC from source = no real key needed.** The frozen wheel hard-validates the key at import
-  (ignores `TLC_DISABLE_ACCOUNT_SERVICE`). The **source** install honors it, so the dev setup is:
-  ```bash
-  uv sync                                              # public releases (keep pyproject as-is)
-  uv pip install -e ../tlc-monorepo -e ../3lc-ultralytics   # editable source overlay
-  ```
-  Then with `.env` holding `TLC_DISABLE_ACCOUNT_SERVICE=1` and a throwaway `TLC_API_KEY`, the
-  **full** suite + eval + 3LC paths run locally with no real key. We use `3lc-ultralytics`
-  (`tlc_ultralytics`), **not** bare ultralytics — bare loses the 3LC integration.
-- `pyproject.toml` stays pointed at the public PyPI/cloudrepo releases so external users can
-  `uv sync` and go. The editable installs are a local overlay only — don't commit them.
-- **Bare-ultralytics is opt-in only**, for the no-source/no-key case (e.g. external CI):
-  `CHESSVISION_ALLOW_BARE_ULTRALYTICS=1`. The YOLO loaders (`_import_yolo` in `utils.py`)
-  otherwise fail loud if `tlc_ultralytics` can't import.
-- `.env` is **not** auto-loaded by pytest/CLI — export it first: `set -a; source .env; set +a`.
+## Setup → see CONTRIBUTING.md
+Full environment setup (the three tiers + macOS / Linux-CUDA platform notes) lives in
+[`CONTRIBUTING.md`](CONTRIBUTING.md). The dev default here is **Tier 2 (source overlay)**:
+`uv sync` + editable `../tlc-monorepo` / `../3lc-ultralytics`, with `.env` holding
+`TLC_DISABLE_ACCOUNT_SERVICE=1` + a throwaway key so the full suite runs offline (the public
+wheel ignores that flag and 403s; the source honors it). Overlay is local-only — don't commit it.
 
-## Commands (use the venv)
+## Gotchas Claude trips on
+- `.env` is **not** auto-loaded by pytest/CLI — export it first: `set -a; source .env; set +a`.
+- macOS cairo: `export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib` before any `cairosvg` path
+  (eval / process-new-raw / render).
+- YOLO loaders (`_import_yolo` in `utils.py`) fail loud if `tlc_ultralytics` is missing; bare
+  ultralytics is opt-in via `CHESSVISION_ALLOW_BARE_ULTRALYTICS=1` (inference only — training
+  stays 3LC-coupled).
+- godfire: prefer `.venv/bin/python` over the `scripts/bin/*.sh` wrappers (they `uv run`); 3LC
+  writes under `~/.local/share/3LC/projects/`; pre-retrain weights backed up in `weights/backup/`.
+- Long training: run nohup'd and poll the log; do NOT write a waiter that greps its own target
+  string (`pgrep -f train_yolo_classifier` matches the waiter itself and loops forever).
+
+## Commands (Tier 2 dev default)
 ```bash
 source .venv/bin/activate
 set -a; source .env; set +a                          # TLC_DISABLE_ACCOUNT_SERVICE=1 + throwaway key
-export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib   # for cairo-using paths
+export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib   # macOS, for cairo-using paths
 
-# Full suite — works locally with source installs, no real key
 python -m pytest tests/ -q
 ./scripts/bin/evaluate.sh
 ./scripts/bin/train_yolo_classifier.sh
 ./scripts/bin/train_yolo_board_extractor.sh
 
-# No source/key at all (external CI smoke test of the CV path only):
+# Offline CV-only smoke test (no source/key):
 CHESSVISION_ALLOW_BARE_ULTRALYTICS=1 python -m pytest tests/test_chessvision.py --no-cov -q
 
-# Lint
 ruff check chessvision/
 ```
 
@@ -60,34 +57,3 @@ ruff check chessvision/
 - Python ≥3.10, ruff (line length 120) + mypy configured in `pyproject.toml`.
 - `chessvision/pytorch_unet/` is a submodule (third-party) — excluded from lint/type/cov.
 - Keep `tlc` usage out of the core `chessvision/` package; it belongs in `scripts/`.
-
-## Running on the godfire GPU node (Linux, RTX 4080)
-
-The project uses its **own standalone `.venv`** here (the earlier idea of a shared parent uv
-workspace at `/home/gubbis/projects/` was abandoned — don't use its venv).
-
-One-time setup:
-```bash
-cd ~/projects/ChessVision-3LC
-uv venv                                                  # fresh .venv in the project
-uv sync --all-extras                                     # public deps (3lc 3.0 wheel, ultralytics, ...)
-uv pip install -e ../tlc-monorepo -e ../3lc-ultralytics  # source overlay (API-compatible with the public 3.0 wheel)
-git submodule update --init                              # UNet submodule (only for the UNet path)
-```
-The editable source overlay matters: the frozen `3lc` wheel ignores `TLC_DISABLE_ACCOUNT_SERVICE`
-and 403s, but the source honors it — so a throwaway key works.
-
-Running things:
-```bash
-export TLC_API_KEY=1 TLC_DISABLE_ACCOUNT_SERVICE=1       # also in the parent .envrc (direnv)
-.venv/bin/python scripts/train/train_yolo_classifier.py --model yolov8n-cls.pt --epochs 40 \
-    --train-table-name initial --val-table-name initial --skip-eval --run-name "..."
-.venv/bin/python scripts/train/prepare_yolo_segmentation_dataset.py   # build YOLO-seg dataset
-.venv/bin/python scripts/eval/compare.py                 # end-to-end eval vs benchmarks/baseline.json
-```
-
-- 3LC writes runs/tables under `/home/gubbis/.local/share/3LC/projects/`.
-- The `scripts/bin/*.sh` wrappers call `uv run` — prefer `.venv/bin/python` directly.
-- All four weights live in `weights/`; the pre-godfire-retrain set is backed up in `weights/backup/`.
-- Long training: run nohup'd and poll the log; do NOT write a waiter that greps its own target
-  string (`pgrep -f train_yolo_classifier` matches the waiter itself and loops forever).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to ChessVision
+
+Thanks for your interest! This guide covers the dev environment in tiers — pick the one that
+matches your access. The **default path works for everyone with a free 3LC account**; the
+other tiers exist for narrower needs.
+
+## Setup tiers
+
+| Tier | Who it's for | Install | Auth | Can run |
+|---|---|---|---|---|
+| **1 — Public (default)** | anyone | `uv sync` (public wheels) | free 3LC key, account service **on** | everything: inference, training, eval, 3LC Dashboard |
+| **2 — Source overlay** | 3LC devs with repo access | wheels + editable `tlc` / `tlc_ultralytics` | throwaway key + account service **off** | everything, **fully offline** (no real key) |
+| **3 — Bare ultralytics** | offline CI, no 3LC at all | `uv sync` | none | **inference only** (no training / 3LC) |
+
+The only reason to use Tier 2 is running with **account service disabled** (`TLC_DISABLE_ACCOUNT_SERVICE=1`):
+the frozen public `3lc` wheel hard-validates the key at import and ignores that flag, while the
+**source** install honors it. Everyone else — including external contributors who want to train —
+just uses Tier 1 with a free key.
+
+> Maintainer note: Tier 2 (source) is the day-to-day internal path, but **Tier 1 (wheels + real
+> key) is what every external user actually hits** and is easy to let rot. Periodically run the
+> suite against a clean `uv sync` (no overlay) + a real key to keep the default experience honest.
+
+---
+
+## Tier 1 — Public (default)
+
+See the [README installation section](README.md#installation). In short:
+
+```bash
+git clone https://github.com/gudbrandtandberg/ChessVision-3LC.git
+cd ChessVision-3LC
+git submodule update --init        # UNet submodule (only needed for the UNet fallback path)
+uv sync --all-extras               # public deps, incl. 3lc-ultralytics + 3lc from the public index
+3lc login <your-free-key>          # from account.3lc.ai
+```
+
+The trained YOLO weights are committed in `weights/`, so inference and the test suite work
+immediately:
+
+```bash
+pytest tests/
+```
+
+## Tier 2 — Source overlay (fully offline, 3LC devs)
+
+For contributors with access to the `tlc` monorepo and `3lc-ultralytics` sources. Layer editable
+installs over the public sync so account service can be disabled (no real key needed):
+
+```bash
+uv sync                                                   # public releases (keep pyproject as-is)
+uv pip install -e ../tlc-monorepo -e ../3lc-ultralytics   # editable source overlay
+```
+
+The source overlay is **local only — don't commit it.** `pyproject.toml` stays pointed at the
+public 3LC index so external `uv sync` keeps working. The overlay tracks the `tlc` dev line, which
+is API-compatible with the public 3.0 wheel.
+
+Then put a throwaway key + the disable flag in `.env` (not auto-loaded — export it yourself):
+
+```bash
+# .env
+TLC_DISABLE_ACCOUNT_SERVICE=1
+TLC_API_KEY=throwaway
+
+set -a; source .env; set +a
+pytest tests/        # full suite + eval + 3LC paths, no real key
+```
+
+We use `3lc-ultralytics` (`tlc_ultralytics`), **not** bare ultralytics — bare loses the 3LC
+integration.
+
+## Tier 3 — Bare ultralytics (inference only)
+
+For environments with no 3LC source and no key (e.g. external CI smoke tests). Opt in explicitly;
+the YOLO loaders otherwise fail loud if `tlc_ultralytics` can't import:
+
+```bash
+CHESSVISION_ALLOW_BARE_ULTRALYTICS=1 python -m pytest tests/test_chessvision.py --no-cov -q
+```
+
+Training stays coupled to `tlc_ultralytics` — this tier is inference only.
+
+---
+
+## Platform notes
+
+### macOS (Apple Silicon, MPS)
+
+- **cairo**: installed via brew (`cairo` 1.18.4) but Python's `find_library` doesn't search
+  `/opt/homebrew/lib`. Export `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib` before any command
+  that imports `cairosvg` (eval / process-new-raw / render paths).
+- Training/inference run on MPS; `channels_last` memory format is skipped on MPS (CPU/CUDA only).
+
+### Linux + CUDA (e.g. an RTX 4080 node)
+
+- Use the project's **own standalone `.venv`** (`uv venv` in the project), not a shared parent
+  workspace venv.
+- 3LC writes runs/tables under `~/.local/share/3LC/projects/`.
+- Long training: run `nohup`'d and poll the log. Do **not** write a waiter that greps its own
+  target string — `pgrep -f train_yolo_classifier` matches the waiter itself and loops forever.
+
+---
+
+## Conventions
+
+- Python ≥3.10; `ruff` (line length 120) + `mypy` configured in `pyproject.toml`.
+- `chessvision/pytorch_unet/` is a third-party submodule — excluded from lint/type/cov.
+- Keep `tlc` usage **out of** the core `chessvision/` package; it belongs in `scripts/`.
+- Lint before pushing: `ruff check chessvision/`.
+
+Direction and priorities live in [`ROADMAP.md`](ROADMAP.md).

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Main scripts for training and evaluating the models are located in the `scripts/
 # Train the YOLO classifier (recommended, requires "yolo" extra)
 ./scripts/bin/train_yolo_classifier.sh
 
-# Or train the default piece classifier
-./scripts/bin/train_piece_classifier.sh
+# Or the fallback (non-YOLO) classifier
+./scripts/bin/train_classifier.sh
 
 # Now that we have trained models, we can run the evaluation suite
 ./scripts/bin/evaluate.sh

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The [3LC](https://3lc.ai) data platform, built by the incredible team at 3LC AI,
 
 ## Features
 
-- Chessboard segmentation using a UNet model
-- Chess piece classification using a YOLO model or a timm-based model
+- Chessboard extraction with a YOLO segmentation model (UNet fallback)
+- Chess piece classification with a YOLO model (timm-based fallback)
 - API for image processing
 - Web interface for uploading and analyzing chess images
 
@@ -36,7 +36,7 @@ The [3LC](https://3lc.ai) data platform, built by the incredible team at 3LC AI,
 - `scripts/`: Scripts for training and evaluating the models
 - `app/`: Code for a development Flask web application and compute server
 - `data/`: Training and evaluation datasets
-- `weights/`: Pre-trained models (not included in the repo - train your own models or contact me for a copy)
+- `weights/`: Trained models — the two best YOLO models (`best_yolo_extractor.pt`, `best_yolo_classifier.pt`) are committed (AGPL-3.0), so inference works on a fresh clone
 - `tests/`: Unit tests for the computer vision code
 
 ## Installation
@@ -52,49 +52,42 @@ cd ChessVision-3LC
 git submodule update --init
 ```
 
-### 2 Install dependencies
+### 2. Install dependencies
 
-Choose either approach:
+Everything installs from **public packages** — no special access required. The YOLO and 3LC
+integrations (`3lc-ultralytics`, `3lc`) come from the public 3LC package index automatically.
+[`uv`](https://docs.astral.sh/uv/) is recommended:
 
-#### Option A: Using uv (Recommended - Faster)
 ```bash
-
-# Install uv on macOS and Linux.
+# Install uv (macOS/Linux); Windows: https://github.com/astral-sh/uv#installation
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Windows: follow instructions at https://github.com/astral-sh/uv?tab=readme-ov-file#installation
-
-# Install dependencies
-uv sync --all-extras
+uv sync                 # core deps (YOLO + 3LC)
+uv sync --all-extras    # also pulls the viz (plotly) and boto (S3) extras
 ```
 
-#### Option B: Using venv and pip
+<details><summary>Alternative: venv + pip</summary>
 
 ```bash
-# Create a new virtual environment
-python -m venv .venv
-
-# Activate the environment
-source .venv/bin/activate
-
-# Install in editable mode with all dependency groups
-pip install -e ".[dev,viz,yolo]"
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[viz,boto]"
 ```
+</details>
 
-### 3. Set up 3LC
+### 3. Get a 3LC API key (free)
 
-1. Get your API key:
-   - Go to [account.3lc.ai](https://accounts.3lc.ai)
-   - Copy your API key
+3LC is integrated throughout the pipeline. A **free single-user account** unlocks everything —
+training, evaluation, and the 3LC Dashboard:
 
-2. Login to 3LC:
-```bash
-# Login with your API key
-3lc login <your-api-key>
+1. Sign up and copy your key at [account.3lc.ai](https://accounts.3lc.ai).
+2. Authenticate, then verify:
+   ```bash
+   3lc login <your-api-key>   # or: export TLC_API_KEY=<your-api-key>
+   3lc --version
+   ```
 
-# Verify installation
-3lc --version
-```
+> Contributors with access to the 3LC source can run **fully offline** (account service
+> disabled, no key). See [CONTRIBUTING.md](CONTRIBUTING.md) for that and other setups.
 
 ## Verify Installation
 
@@ -108,13 +101,13 @@ python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 # Check if mps is available
 python -c "import torch; print('MPS available:', torch.backends.mps.is_available())"
 
-# Run tests (requires trained models)
+# Run tests (the committed weights are used automatically)
 pytest tests/
 ```
 
 ## Examples
 
-**Note:** You must have trained models in the weights directory to run the examples. See the [Training](#training) section for more details.
+**Note:** The committed YOLO weights in `weights/` are used by default, so the examples run on a fresh clone. To train your own, see the [Training](#training) section.
 
 ### Quick Start
 
@@ -137,13 +130,13 @@ python examples/detailed-example.py
 Main scripts for training and evaluating the models are located in the `scripts/` directory.
 
 ```bash
-# Train the YOLO board extractor (recommended, requires "yolo" extra)
+# Train the YOLO board extractor (recommended)
 ./scripts/bin/train_yolo_board_extractor.sh
 
 # Or the fallback (non-YOLO / UNet) board extractor
 ./scripts/bin/train_board_extractor.sh
 
-# Train the YOLO classifier (recommended, requires "yolo" extra)
+# Train the YOLO classifier (recommended)
 ./scripts/bin/train_yolo_classifier.sh
 
 # Or the fallback (non-YOLO) classifier
@@ -170,7 +163,7 @@ python scripts/merge_new_raw/merge_new_test.py
 
 The chessvision solution consists of several steps:
 
-1. Board detection using a UNet model to segment the chessboard from the background
+1. Board extraction using a YOLO segmentation model to segment the chessboard from the background (UNet fallback)
 2. Contour detection and filtering to identify the chessboard boundaries
 3. Perspective transform to extract the chessboard
 4. Individual square extraction
@@ -208,6 +201,12 @@ In addition, there is a practically endless supply of new data collected through
 ### Run evaluation suite
 
 ![ChessVision Pipeline](examples/screenshots/test_results.png)
+
+## Contributing
+
+Contributions are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) covers the setup tiers
+(public wheels + free key, fully-offline source overlay, and the no-3LC inference-only
+escape hatch) and the macOS / Linux-CUDA platform notes.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ python examples/detailed-example.py
 Main scripts for training and evaluating the models are located in the `scripts/` directory.
 
 ```bash
-# Train the board extractor
+# Train the YOLO board extractor (recommended, requires "yolo" extra)
+./scripts/bin/train_yolo_board_extractor.sh
+
+# Or the fallback (non-YOLO / UNet) board extractor
 ./scripts/bin/train_board_extractor.sh
 
 # Train the YOLO classifier (recommended, requires "yolo" extra)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,6 +76,10 @@ When the two diverge, Claude trades off case-by-case and flags it here.
 - Active-learning loop driven by extraction-confidence / embedding outliers.
 - Latency/packaging pass; revisit the Flask app + compute server.
 - End-to-end FEN accuracy (not just per-square) as a headline metric.
+- Board extraction via corner-keypoint regression (YOLO-pose): regress the 4 board
+  corners directly instead of segment-mask → contour → perspective transform. Early spike
+  in the closed #6 (`notebooks/convert_to_kpts.py` builds a keypoints table from existing
+  masks via `_find_quadrangle`).
 
 ## Open questions for Gudbrand
 - For the harder test set: label budget / how the 600k uploads' ground-truth FENs get created

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,6 +69,9 @@ When the two diverge, Claude trades off case-by-case and flags it here.
 - **Decouple metrics tests from tlc** (move pure functions out of `evaluate.py`) + add
   `integration` pytest markers so `-m "not integration"` is the fast offline lane.
 - **Audit remaining 3.x-untested scripts**: `process_new_raw/*`, `merge_new_raw/*` (need S3).
+- **Periodically verify the public-wheel path**: run the suite against a clean `uv sync` (no
+  source overlay) + a real free key. That's the default external-user experience (Tier 1 in
+  CONTRIBUTING) and is easy to let rot while we live on the source overlay.
 
 ## Later
 


### PR DESCRIPTION
Started as the small triage-fallout cleanup, grew into a docs restructure so the project is approachable for casual contributors, not just maintainers with 3LC source access.

## Setup restructured by audience
The old docs were written from the privileged (source-overlay + throwaway-key) vantage point, so an external contributor hit paths/keys they don't have. Reorganized by **what works without special access**:

- **README** now leads with the **public default path**: `uv sync` (public wheels — `3lc-ultralytics` + `3lc` are core deps from the public index) + a **free single-user key** from [account.3lc.ai](https://accounts.3lc.ai) unlocks *everything*, including training. Committed weights mean inference + tests work on a fresh clone.
- **New `CONTRIBUTING.md`** documents three setup tiers + platform notes:
  1. Public wheels + free key (default)
  2. Source overlay → fully offline (`TLC_DISABLE_ACCOUNT_SERVICE=1`; only the source honors it)
  3. Bare ultralytics → inference-only escape hatch
  - macOS (cairo/DYLD, MPS) and Linux-CUDA (standalone `.venv`, godfire) subsections.
- **CLAUDE.md** trimmed: duplicated setup/godfire blocks → pointers into CONTRIBUTING; keeps the agent-operational gotchas + a Tier-2 command quick-ref. (Single source of truth — duplication is what let it drift stale.)

## Stale-doc fixes folded in
- README: dropped "weights not in repo / contact me for a copy", the nonexistent `train_piece_classifier.sh` and `"yolo"` extra, and UNet-as-primary wording (YOLO is default; UNet/timm are fallbacks). Surfaced `train_yolo_board_extractor.sh`.
- CLAUDE.md: weights **are** committed now (AGPL); dropped the stale "tlc 3.1" label (source is API-compatible with the public 3.0 wheel).

## ROADMAP
- Captured corner-keypoint board extraction (YOLO-pose) under *Later* — gated on a bigger/harder test set, framed as a clean A/B vs the current instance-seg path (refs the closed #6 spike).
- Added a maintenance item: periodically run the suite against a clean `uv sync` + real key, since the public-wheel path is the default external experience and easy to let rot while we live on the source overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)